### PR TITLE
Fix NuSMV executor command-prefix handling

### DIFF
--- a/backend/src/main/java/cn/edu/nju/Iot_Verify/component/nusmv/executor/NusmvExecutor.java
+++ b/backend/src/main/java/cn/edu/nju/Iot_Verify/component/nusmv/executor/NusmvExecutor.java
@@ -126,22 +126,35 @@ public class NusmvExecutor {
         boolean isWindows = System.getProperty("os.name").toLowerCase().contains("windows");
 
         if (commandPrefix != null && !commandPrefix.isEmpty()) {
+            String fullCommand = commandPrefix + " " + quoteForShell(nusmvPath, isWindows)
+                    + " " + quoteForShell(smvFile.getAbsolutePath(), isWindows);
             if (isWindows) {
                 command.add("cmd.exe");
                 command.add("/c");
-                command.add(commandPrefix);
+                command.add(fullCommand);
             } else {
                 command.add("sh");
                 command.add("-c");
-                command.add(commandPrefix);
+                command.add(fullCommand);
             }
+            return command;
         } else if (isWindows) {
             command.add("cmd.exe");
             command.add("/c");
+            command.add(quoteForShell(nusmvPath, true) + " " + quoteForShell(smvFile.getAbsolutePath(), true));
+            return command;
         }
         command.add(nusmvPath);
         command.add(smvFile.getAbsolutePath());
         return command;
+    }
+
+    private String quoteForShell(String value, boolean isWindows) {
+        if (value == null) return "";
+        if (isWindows) {
+            return '"' + value.replace("\"", "\\\"") + '"';
+        }
+        return '\'' + value.replace("'", "'\"'\"'") + '\'';
     }
 
     private long getTimeoutFromEnvironment() {

--- a/backend/src/test/java/cn/edu/nju/Iot_Verify/component/nusmv/executor/NusmvExecutorCommandTest.java
+++ b/backend/src/test/java/cn/edu/nju/Iot_Verify/component/nusmv/executor/NusmvExecutorCommandTest.java
@@ -1,0 +1,51 @@
+package cn.edu.nju.Iot_Verify.component.nusmv.executor;
+
+import cn.edu.nju.Iot_Verify.configure.NusmvConfig;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.lang.reflect.Method;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class NusmvExecutorCommandTest {
+
+    @SuppressWarnings("unchecked")
+    private List<String> invokeBuildCommand(NusmvExecutor executor, File smvFile) throws Exception {
+        Method method = NusmvExecutor.class.getDeclaredMethod("buildCommand", File.class);
+        method.setAccessible(true);
+        return (List<String>) method.invoke(executor, smvFile);
+    }
+
+    @Test
+    void buildCommand_withPrefixOnUnix_wrapsInSingleShellCommand() throws Exception {
+        NusmvConfig config = new NusmvConfig();
+        config.setPath("/opt/NuSMV/bin/NuSMV");
+        config.setCommandPrefix("wsl");
+
+        NusmvExecutor executor = new NusmvExecutor(config);
+        List<String> command = invokeBuildCommand(executor, new File("/tmp/model.smv"));
+
+        assertEquals("sh", command.get(0));
+        assertEquals("-c", command.get(1));
+        assertEquals(3, command.size());
+        assertTrue(command.get(2).contains("wsl"));
+        assertTrue(command.get(2).contains("NuSMV"));
+        assertTrue(command.get(2).contains("model.smv"));
+    }
+
+    @Test
+    void buildCommand_withoutPrefixOnUnix_keepsRawExecutableAndArgs() throws Exception {
+        NusmvConfig config = new NusmvConfig();
+        config.setPath("/opt/NuSMV/bin/NuSMV");
+        config.setCommandPrefix("");
+
+        NusmvExecutor executor = new NusmvExecutor(config);
+        List<String> command = invokeBuildCommand(executor, new File("/tmp/model.smv"));
+
+        assertEquals(2, command.size());
+        assertEquals("/opt/NuSMV/bin/NuSMV", command.get(0));
+        assertEquals("/tmp/model.smv", command.get(1));
+    }
+}


### PR DESCRIPTION
### Motivation
- `NusmvExecutor.buildCommand` previously passed only the configured `command-prefix` to the shell when present, causing the NuSMV executable path and .smv file to be dropped from the shell invocation and preventing NuSMV from launching correctly.
- The change also aims to safely handle spaces in executable and file paths on both Unix and Windows when a prefix is used.

### Description
- Updated `NusmvExecutor.buildCommand` to assemble a single shell command string when `commandPrefix` is set, so the prefix, the quoted NuSMV executable path and the quoted .smv file are executed together (file: `src/main/java/.../NusmvExecutor.java`).
- Added `quoteForShell` helper to quote paths safely for Unix (`'...'`) and Windows (`"..."`) shells, and adjusted Windows `cmd.exe /c` branch to return a single combined command string.
- Added unit test `NusmvExecutorCommandTest` to verify command construction behavior for the prefix and non-prefix Unix cases (file: `src/test/java/.../NusmvExecutorCommandTest.java`).

### Testing
- Attempted to run the new unit test with `mvn -Dtest=NusmvExecutorCommandTest test`, but execution failed due to Maven being unable to resolve the Spring Boot parent POM from Maven Central (HTTP 403) in this environment, so tests did not run.
- Also attempted `mvn test -Dtest='*nusmv*','SmvGeneratorFixesTest'` and it failed for the same Maven parent POM resolution error, preventing further automated verification in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69967d49cc3c832aaad3df5ddc4c2993)